### PR TITLE
Improve chat history and per-message TTS UI

### DIFF
--- a/frontend/components/ChatWindow.tsx
+++ b/frontend/components/ChatWindow.tsx
@@ -1,10 +1,10 @@
 "use client";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import MessageBubble, { ChatMsg } from "./MessageBubble";
 import TypingDots from "./TypingDots";
 import Spinner from "./Spinner";
 import ImageLightbox from "./ImageLightbox";
-import { ImageIcon, Mic, Send, Volume2 } from "lucide-react";
+import { ImageIcon, ArrowUp } from "lucide-react";
 import Recorder from "./Recorder";
 
 function useApiBase() {
@@ -33,11 +33,14 @@ export default function ChatWindow({
   const [sending, setSending] = useState(false);
   const [assistantTyping, setAssistantTyping] = useState(false);
   const [imgLoading, setImgLoading] = useState(false);
-  const [ttsLoading, setTtsLoading] = useState(false);
   const [lightbox, setLightbox] = useState<string | null>(null);
-  const [audioUrl, setAudioUrl] = useState<string | null>(null);
-  const audioRef = useRef<HTMLAudioElement>(null);
   const base = useApiBase();
+
+  useEffect(() => {
+    if (seedMessages) {
+      setMsgs(seedMessages.map((m) => ({ role: m.role, content: m.content })));
+    }
+  }, [seedMessages]);
 
   async function send(text?: string) {
     const message = (text ?? input).trim();
@@ -63,20 +66,7 @@ export default function ChatWindow({
 
       const reply = data?.reply ?? "(no reply)";
       setMsgs((m) => [...m, { role: "assistant", content: reply }]);
-
-      // TTS (optional, with spinner)
-      setTtsLoading(true);
-      try {
-        const tts = await fetch(base + "/tts?text=" + encodeURIComponent(stripMarkdown(reply)));
-        if (tts.ok) {
-          const blob = await tts.blob();
-          const url = URL.createObjectURL(blob);
-          setAudioUrl(url);
-          setTimeout(() => audioRef.current?.play(), 100);
-        }
-      } finally {
-        setTtsLoading(false);
-      }
+      window.dispatchEvent(new Event("chat-updated"));
     } catch (e) {
       setMsgs((m) => [...m, { role: "assistant", content: "Sorry, something went wrong." }]);
     } finally {
@@ -113,35 +103,45 @@ export default function ChatWindow({
     }
   }
 
+  async function speak(text: string) {
+    const res = await fetch(
+      base + "/tts?text=" + encodeURIComponent(stripMarkdown(text))
+    );
+    if (res.ok) {
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const audio = new Audio(url);
+      audio.play();
+    }
+  }
+
   useEffect(() => {
     // Preload book list silently; helpful for first load warmup
     fetch(base + "/books").catch(() => {});
   }, [base]);
 
   return (
-    <div className="mx-auto max-w-3xl p-6 space-y-4">
+    <div className="mx-auto flex h-screen max-w-3xl flex-col p-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="mb-4 flex items-center justify-between">
         <h1 className="text-xl font-semibold tracking-tight">Smart Librarian</h1>
-        <div className="flex items-center gap-2">
-          <Recorder onText={(t) => setInput(t)} />
-          <button
-            onClick={genCover}
-            disabled={imgLoading}
-            className="inline-flex items-center gap-2 rounded border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 hover:shadow disabled:opacity-60"
-          >
-            <ImageIcon className="h-4 w-4" /> {imgLoading ? "Generating..." : "Generate cover"}
-          </button>
-        </div>
+        <button
+          onClick={genCover}
+          disabled={imgLoading}
+          className="inline-flex items-center gap-2 rounded border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 hover:shadow disabled:opacity-60"
+        >
+          <ImageIcon className="h-4 w-4" /> {imgLoading ? "Generating..." : "Generate cover"}
+        </button>
       </div>
 
       {/* Chat area */}
-      <div className="rounded-2xl border border-slate-200 dark:border-slate-700 p-4 space-y-3 bg-white dark:bg-slate-800 min-h-[320px]">
+      <div className="flex-1 overflow-y-auto rounded-2xl border border-slate-200 dark:border-slate-700 p-4 space-y-3 bg-white dark:bg-slate-800">
         {msgs.map((m, i) => (
           <MessageBubble
             key={i}
             msg={m}
             onCopy={(t) => navigator.clipboard.writeText(t)}
+            onSpeak={speak}
             onImageClick={(src) => setLightbox(src)}
           />
         ))}
@@ -149,6 +149,11 @@ export default function ChatWindow({
           <div className="flex items-center gap-2 text-slate-500">
             <TypingDots />
             <span className="text-sm">Assistant is thinking…</span>
+          </div>
+        )}
+        {msgs.length === 0 && !assistantTyping && (
+          <div className="flex h-full items-center justify-center text-center text-slate-500">
+            Ask a question to start the conversation.
           </div>
         )}
       </div>
@@ -159,7 +164,7 @@ export default function ChatWindow({
           e.preventDefault();
           send();
         }}
-        className="flex items-center gap-2"
+        className="mt-4 flex items-center gap-2"
       >
         <input
           className="flex-1 rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-3 py-3 shadow-sm focus:ring-2 focus:ring-slate-300 dark:focus:ring-slate-700"
@@ -167,23 +172,14 @@ export default function ChatWindow({
           value={input}
           onChange={(e) => setInput(e.target.value)}
         />
+        <Recorder onText={(t) => setInput(t)} />
         <button
           disabled={sending}
-          className="inline-flex items-center gap-2 rounded-xl bg-slate-900 text-white dark:bg-white dark:text-slate-900 px-4 py-3 hover:opacity-95 disabled:opacity-60"
+          className="inline-flex items-center justify-center rounded-xl bg-slate-900 text-white dark:bg-white dark:text-slate-900 p-3 hover:opacity-95 disabled:opacity-60"
         >
-          {sending ? <Spinner className="h-4 w-4" /> : <Send className="h-4 w-4" />} Send
+          {sending ? <Spinner className="h-4 w-4" /> : <ArrowUp className="h-4 w-4" />}
         </button>
       </form>
-
-      {/* Audio player + indicator */}
-      <div className="flex items-center gap-2">
-        <audio ref={audioRef} src={audioUrl ?? undefined} controls className="w-full" />
-        {ttsLoading && (
-          <div className="inline-flex items-center gap-1 text-sm text-slate-500">
-            <Spinner /> <Volume2 className="h-3.5 w-3.5" /> Generating audio…
-          </div>
-        )}
-      </div>
 
       {lightbox && <ImageLightbox src={lightbox} onClose={() => setLightbox(null)} />}
     </div>

--- a/frontend/components/MessageBubble.tsx
+++ b/frontend/components/MessageBubble.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import cn from "classnames";
 import ReactMarkdown from "react-markdown";
-import { Bot, User, Copy, Check } from "lucide-react";
+import { Bot, User, Copy, Check, Volume2 } from "lucide-react";
 
 export type ChatMsg = {
   role: "user" | "assistant";
@@ -24,10 +24,11 @@ function Avatar({ role }: { role: "user" | "assistant" }) {
   );
 }
 
-export default function MessageBubble({ msg, onCopy, onImageClick }: {
+export default function MessageBubble({ msg, onCopy, onImageClick, onSpeak }: {
   msg: ChatMsg;
   onCopy?: (text: string) => void;
   onImageClick?: (src: string) => void;
+  onSpeak?: (text: string) => void;
 }) {
   const [copied, setCopied] = React.useState(false);
   async function doCopy() {
@@ -38,7 +39,7 @@ export default function MessageBubble({ msg, onCopy, onImageClick }: {
   }
 
   const bubbleClasses = cn(
-    "group relative rounded-2xl px-3 py-2 text-[0.95rem] leading-relaxed",
+    "rounded-2xl px-3 py-2 text-[0.95rem] leading-relaxed",
     "border shadow-sm",
     msg.role === "user"
       ? "bg-slate-100 dark:bg-slate-700 border-slate-200 dark:border-slate-600"
@@ -53,15 +54,28 @@ export default function MessageBubble({ msg, onCopy, onImageClick }: {
           <div className="prose prose-slate dark:prose-invert prose-p:my-2 prose-pre:my-2 prose-strong:font-semibold">
             <ReactMarkdown>{msg.content}</ReactMarkdown>
           </div>
-          <button
-            onClick={doCopy}
-            className="absolute -right-2 -top-2 hidden group-hover:flex items-center gap-1 rounded-full border px-2 py-1 text-xs bg-white/80 dark:bg-slate-900/70 backdrop-blur border-slate-200 dark:border-slate-700"
-            title="Copy"
-            aria-label="Copy message"
-          >
-            {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-          </button>
         </div>
+
+        {msg.role === "assistant" && (
+          <div className="flex items-center gap-2 text-slate-500">
+            <button
+              onClick={doCopy}
+              className="p-1 hover:text-slate-700 dark:hover:text-slate-300"
+              title="Copy"
+              aria-label="Copy message"
+            >
+              {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+            </button>
+            <button
+              onClick={() => onSpeak?.(msg.content)}
+              className="p-1 hover:text-slate-700 dark:hover:text-slate-300"
+              title="Play audio"
+              aria-label="Play audio"
+            >
+              <Volume2 className="h-4 w-4" />
+            </button>
+          </div>
+        )}
 
         {msg.imageB64 && (
           <img

--- a/frontend/components/Recorder.tsx
+++ b/frontend/components/Recorder.tsx
@@ -31,15 +31,17 @@ export default function Recorder({ onText }: { onText: (text: string) => void })
     setRecording(false);
   }
 
-   return (
+  return (
     <button
       onClick={() => (recording ? stop() : start())}
       aria-label={recording ? "Stop recording" : "Start recording"}
-      className={`inline-flex items-center gap-2 rounded border px-3 py-2 ${
-        recording ? "bg-red-600 text-white border-red-700" : "bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700 hover:shadow"
+      className={`inline-flex items-center justify-center rounded-xl border p-3 ${
+        recording
+          ? "bg-red-600 text-white border-red-700"
+          : "bg-white dark:bg-slate-800 border-slate-300 dark:border-slate-600 hover:shadow"
       }`}
     >
-      <Mic className="h-4 w-4" /> {recording ? "Stop" : "Record"}
+      <Mic className="h-4 w-4" />
     </button>
   );
 }

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -26,6 +26,12 @@ export default function Sidebar(){
 }
   useEffect(()=>{ load().catch(()=>{}); },[base]);
 
+  useEffect(() => {
+    const handler = () => load().catch(() => {});
+    window.addEventListener("chat-updated", handler);
+    return () => window.removeEventListener("chat-updated", handler);
+  }, [base]);
+
   async function newChat(){
     const res = await fetch(base+"/chats", { method: "POST"});
     const data = await res.json();


### PR DESCRIPTION
## Summary
- derive chat titles from the conversation and update on first user message
- show existing history when opening chats and keep composer at bottom with new recorder and arrow send
- add per-message copy and text-to-speech controls

## Testing
- `python -m py_compile backend/app/routers/chat.py`
- `pnpm lint` *(fails: prompts for ESLint setup)*
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_b_689dfc117acc83338813e9d98115c6d7