### PR TITLE
feat: generate images from responses and refine recorder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.env
+.env.*
+.next/
+__pycache__/

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -122,6 +122,10 @@ def chat(body: ChatIn):
             s.add(chat)
             s.commit()
             s.refresh(chat)
+        else:
+            # Update default title on first user message
+            if (chat.title or "") == "New Chat":
+                chat.title = user_input[:48] + ("…" if len(user_input) > 48 else "")
 
         # Store user and assistant messages
         s.add(Message(chat_id=chat.id, role="user", content=user_input))

--- a/backend/app/routers/image.py
+++ b/backend/app/routers/image.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Query
 from openai import OpenAI
-import os, base64  # base64 kept if you later want to decode/save files
+import os
 from typing import Optional
+from datetime import datetime
 
 from ..db import get_session
-from ..models import ImageAsset
+from ..models import ImageAsset, Chat
 
 
 router = APIRouter(prefix="", tags=["image"])
@@ -24,10 +25,24 @@ def gen_image(
     res = client.images.generate(model=model, prompt=prompt, size="1024x1024")
     b64 = res.data[0].b64_json
 
-    # Persist generated image
+    # Persist chat and generated image
     with get_session() as s:
-        asset = ImageAsset(chat_id=chat_id, title=title or prompt[:64], b64=b64)
+        chat = s.get(Chat, chat_id) if chat_id else None
+        if chat is None:
+            title_text = title or prompt[:48] + ("…" if len(prompt) > 48 else "")
+            chat = Chat(title=title_text)
+            s.add(chat)
+            s.commit()
+            s.refresh(chat)
+        else:
+            if (chat.title or "") == "New Chat":
+                chat.title = prompt[:48] + ("…" if len(prompt) > 48 else "")
+
+        asset = ImageAsset(chat_id=chat.id, title=title or prompt[:64], b64=b64)
         s.add(asset)
+        chat.updated_at = datetime.utcnow()
+        s.add(chat)
         s.commit()
         s.refresh(asset)
-        return {"image_b64": b64, "id": asset.id}
+
+        return {"image_b64": b64, "id": asset.id, "chat_id": chat.id}

--- a/frontend/app/chat/[id]/page.tsx
+++ b/frontend/app/chat/[id]/page.tsx
@@ -1,11 +1,14 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
 import ChatWindow from "@/components/ChatWindow";
+import Spinner from "@/components/Spinner";
 
 export default function ChatById({ params }: { params: { id: string } }){
   const chatId = Number(params.id);
   // Prime ChatWindow by loading history once (optional — ChatWindow can also load on its own)
-  const [seed, setSeed] = useState<{role:"user"|"assistant";content:string}[]|null>(null);
+  const [seed, setSeed] = useState<
+    { role: "user" | "assistant"; content: string; image_b64?: string }[] | null
+  >(null);
 
   const base = useMemo(()=>process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000",[]);
   useEffect(()=>{
@@ -13,6 +16,14 @@ export default function ChatById({ params }: { params: { id: string } }){
       setSeed(data?.messages || []);
     }).catch(()=>setSeed([]));
   },[base,chatId]);
+
+  if (seed === null) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <Spinner className="h-8 w-8" />
+      </div>
+    );
+  }
 
   return <ChatWindow chatId={chatId} seedMessages={seed || undefined}/>;
 }

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -18,3 +18,25 @@
 .typing-dots > i:nth-child(2){ animation-delay: .15s; }
 .typing-dots > i:nth-child(3){ animation-delay: .3s; }
 @keyframes bounce { 0%,80%,100%{ transform: translateY(0); opacity:.4 } 40%{ transform: translateY(-3px); opacity:1 } }
+
+/* recording indicator */
+.recording-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 2px;
+}
+.recording-bars span {
+  display: block;
+  width: 3px;
+  height: 12px;
+  background: rgb(220 38 38); /* red-600 */
+  animation: recording-bar 1s infinite ease-in-out;
+}
+.recording-bars span:nth-child(2) { animation-delay: -0.8s; }
+.recording-bars span:nth-child(3) { animation-delay: -0.6s; }
+.recording-bars span:nth-child(4) { animation-delay: -0.4s; }
+.recording-bars span:nth-child(5) { animation-delay: -0.2s; }
+@keyframes recording-bar {
+  0%,100% { transform: scaleY(0.4); }
+  50% { transform: scaleY(1); }
+}

--- a/frontend/app/library/page.tsx
+++ b/frontend/app/library/page.tsx
@@ -1,28 +1,37 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
 import ImageLightbox from "@/components/ImageLightbox";
+import Spinner from "@/components/Spinner";
 
 type Img = { id:number; chat_id:number|null; title?:string|null; b64:string };
 
 export default function LibraryPage(){
   const base = useMemo(()=>process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000",[]);
-  const [imgs, setImgs] = useState<Img[]>([]);
+  const [imgs, setImgs] = useState<Img[] | null>(null);
   const [open, setOpen] = useState<string|null>(null);
 
-  useEffect(()=>{ fetch(base+"/images").then(r=>r.json()).then(setImgs).catch(()=>{}); },[base]);
+  useEffect(()=>{ fetch(base+"/images").then(r=>r.json()).then(setImgs).catch(()=>setImgs([])); },[base]);
 
   return (
     <div className="p-6 space-y-4">
       <h2 className="text-xl font-semibold">Library</h2>
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
-        {imgs.map(im=> (
-          <img key={im.id} src={`data:image/png;base64,${im.b64}`} alt={im.title || "image"}
-               className="rounded-xl border border-slate-200 dark:border-slate-700 cursor-zoom-in hover:opacity-95"
-               onClick={()=>setOpen(`data:image/png;base64,${im.b64}`)}/>
-        ))}
-        {imgs.length===0 && <div className="text-slate-500">No images yet.</div>}
-      </div>
-      {open && <ImageLightbox src={open} onClose={()=>setOpen(null)}/>} 
+      {imgs === null ? (
+        <div className="flex items-center justify-center py-10">
+          <Spinner className="h-8 w-8" />
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+            {imgs.map(im=> (
+              <img key={im.id} src={`data:image/png;base64,${im.b64}`} alt={im.title || "image"}
+                   className="rounded-xl border border-slate-200 dark:border-slate-700 cursor-zoom-in hover:opacity-95"
+                   onClick={()=>setOpen(`data:image/png;base64,${im.b64}`)}/>
+            ))}
+          </div>
+          {imgs.length===0 && <div className="text-slate-500">No images yet.</div>}
+        </>
+      )}
+      {open && <ImageLightbox src={open} onClose={()=>setOpen(null)}/>}
     </div>
   );
 }

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,9 +1,4 @@
 import ChatWindow from "@/components/ChatWindow";
-export default function Home(){
-  return (
-    <div className="p-6">
-      <div className="mb-3 text-slate-500 text-sm">Tip: click <b>New chat</b> in the left sidebar to persist your conversation.</div>
-      <ChatWindow />
-    </div>
-  );
+export default function Home() {
+  return <ChatWindow />;
 }

--- a/frontend/components/ChatWindow.tsx
+++ b/frontend/components/ChatWindow.tsx
@@ -4,7 +4,7 @@ import MessageBubble, { ChatMsg } from "./MessageBubble";
 import TypingDots from "./TypingDots";
 import Spinner from "./Spinner";
 import ImageLightbox from "./ImageLightbox";
-import { ImageIcon, Mic, Send, Volume2 } from "lucide-react";
+import { Send, ImagePlus } from "lucide-react";
 import Recorder from "./Recorder";
 
 function useApiBase() {
@@ -24,26 +24,64 @@ export default function ChatWindow({
   seedMessages,
 }: {
   chatId?: number;
-  seedMessages?: { role: "user" | "assistant"; content: string }[];
+  seedMessages?: {
+    role: "user" | "assistant";
+    content: string;
+    imageB64?: string;
+    image_b64?: string;
+  }[];
 }) {
   const [input, setInput] = useState("");
   const [msgs, setMsgs] = useState<ChatMsg[]>(
-    seedMessages?.map((m) => ({ role: m.role, content: m.content })) || []
+    seedMessages?.map((m) => ({
+      role: m.role,
+      content: m.content,
+      imageB64: m.imageB64 || m.image_b64,
+    })) || []
   );
   const [sending, setSending] = useState(false);
-  const [assistantTyping, setAssistantTyping] = useState(false);
-  const [imgLoading, setImgLoading] = useState(false);
-  const [ttsLoading, setTtsLoading] = useState(false);
+  const [status, setStatus] = useState<"thinking" | "generating" | null>(null);
   const [lightbox, setLightbox] = useState<string | null>(null);
   const [audioUrl, setAudioUrl] = useState<string | null>(null);
+  const [speakingIdx, setSpeakingIdx] = useState<number | null>(null);
+  const [recording, setRecording] = useState(false);
   const audioRef = useRef<HTMLAudioElement>(null);
   const base = useApiBase();
+
+  useEffect(() => {
+    if (seedMessages) {
+      setMsgs(
+        seedMessages.map((m) => ({
+          role: m.role,
+          content: m.content,
+          imageB64: m.imageB64 || (m as any).image_b64,
+        }))
+      );
+    }
+  }, [seedMessages]);
+
+  async function speak(text: string, idx: number) {
+    setSpeakingIdx(idx);
+    try {
+      const tts = await fetch(
+        base + "/tts?text=" + encodeURIComponent(stripMarkdown(text))
+      );
+      if (tts.ok) {
+        const blob = await tts.blob();
+        const url = URL.createObjectURL(blob);
+        setAudioUrl(url);
+        setTimeout(() => audioRef.current?.play(), 100);
+      }
+    } finally {
+      setSpeakingIdx(null);
+    }
+  }
 
   async function send(text?: string) {
     const message = (text ?? input).trim();
     if (!message || sending) return;
     setSending(true);
-    setAssistantTyping(true);
+    setStatus("thinking");
     setInput("");
     setMsgs((m) => [...m, { role: "user", content: message }]);
 
@@ -63,53 +101,56 @@ export default function ChatWindow({
 
       const reply = data?.reply ?? "(no reply)";
       setMsgs((m) => [...m, { role: "assistant", content: reply }]);
-
-      // TTS (optional, with spinner)
-      setTtsLoading(true);
-      try {
-        const tts = await fetch(base + "/tts?text=" + encodeURIComponent(stripMarkdown(reply)));
-        if (tts.ok) {
-          const blob = await tts.blob();
-          const url = URL.createObjectURL(blob);
-          setAudioUrl(url);
-          setTimeout(() => audioRef.current?.play(), 100);
-        }
-      } finally {
-        setTtsLoading(false);
-      }
+      window.dispatchEvent(new Event("chats-changed"));
     } catch (e) {
       setMsgs((m) => [...m, { role: "assistant", content: "Sorry, something went wrong." }]);
     } finally {
-      setAssistantTyping(false);
+      setStatus(null);
       setSending(false);
     }
   }
 
-  async function genCover() {
-    if (imgLoading) return;
-    setImgLoading(true);
+  async function generateImage() {
+    if (sending) return;
+    const lastAssistant = [...msgs].reverse().find((m) => m.role === "assistant");
+    if (!lastAssistant) {
+      setMsgs((m) => [
+        ...m,
+        { role: "assistant", content: "No context for image generation." },
+      ]);
+      return;
+    }
+    setSending(true);
+    setStatus("generating");
     try {
-      const last = [...msgs].reverse().find((m) => m.role === "assistant");
-      const prompt = last
-        ? `Create a tasteful book cover illustration for this recommendation: ${last.content}`
-        : "Create a tasteful, minimalist book cover with abstract shapes and soft gradients.";
-
       const res = await fetch(
-        base +
-          "/image?prompt=" +
-          encodeURIComponent(prompt) +
-          (chatId ? `&chat_id=${chatId}` : "")
+        `${base}/image?prompt=${encodeURIComponent(lastAssistant.content)}&chat_id=${chatId ?? ""}`
       );
       const data = await res.json();
-      const b64 = data?.image_b64 ?? null;
-      if (b64) {
-        // Push image inside the chat as an assistant message
-        setMsgs((m) => [...m, { role: "assistant", content: "Generated cover:", imageB64: b64 }]);
+      if (!chatId && data?.chat_id) {
+        window.location.href = "/chat/" + data.chat_id;
+        return;
       }
-    } catch (e) {
-      setMsgs((m) => [...m, { role: "assistant", content: "Couldn't generate image this time." }]);
+      if (data?.image_b64) {
+        setMsgs((m) => [
+          ...m,
+          { role: "assistant", content: "", imageB64: data.image_b64 },
+        ]);
+        window.dispatchEvent(new Event("chats-changed"));
+      } else {
+        setMsgs((m) => [
+          ...m,
+          { role: "assistant", content: "Failed to generate image." },
+        ]);
+      }
+    } catch {
+      setMsgs((m) => [
+        ...m,
+        { role: "assistant", content: "Failed to generate image." },
+      ]);
     } finally {
-      setImgLoading(false);
+      setStatus(null);
+      setSending(false);
     }
   }
 
@@ -119,72 +160,73 @@ export default function ChatWindow({
   }, [base]);
 
   return (
-    <div className="mx-auto max-w-3xl p-6 space-y-4">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <h1 className="text-xl font-semibold tracking-tight">Smart Librarian</h1>
-        <div className="flex items-center gap-2">
-          <Recorder onText={(t) => setInput(t)} />
-          <button
-            onClick={genCover}
-            disabled={imgLoading}
-            className="inline-flex items-center gap-2 rounded border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 px-3 py-2 hover:shadow disabled:opacity-60"
-          >
-            <ImageIcon className="h-4 w-4" /> {imgLoading ? "Generating..." : "Generate cover"}
-          </button>
-        </div>
-      </div>
-
-      {/* Chat area */}
-      <div className="rounded-2xl border border-slate-200 dark:border-slate-700 p-4 space-y-3 bg-white dark:bg-slate-800 min-h-[320px]">
-        {msgs.map((m, i) => (
-          <MessageBubble
-            key={i}
-            msg={m}
-            onCopy={(t) => navigator.clipboard.writeText(t)}
-            onImageClick={(src) => setLightbox(src)}
-          />
-        ))}
-        {assistantTyping && (
-          <div className="flex items-center gap-2 text-slate-500">
-            <TypingDots />
-            <span className="text-sm">Assistant is thinking…</span>
+    <div className="flex h-full flex-col">
+      <div className="flex-1 overflow-y-auto px-4">
+        {msgs.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center gap-6 text-center">
+            <h1 className="text-2xl font-semibold">What can I help you with?</h1>
+          </div>
+        ) : (
+          <div className="space-y-4 py-4">
+            {msgs.map((m, i) => (
+              <MessageBubble
+                key={i}
+                msg={m}
+                onCopy={(t) => navigator.clipboard.writeText(t)}
+                onImageClick={(src) => setLightbox(src)}
+                onSpeak={m.role === "assistant" ? () => speak(m.content, i) : undefined}
+                speaking={speakingIdx === i}
+              />
+            ))}
+            {status && (
+              <div className="flex items-center gap-2 text-slate-500">
+                <TypingDots />
+                <span className="text-sm">
+                  {status === "generating" ? "Generating image…" : "Assistant is thinking…"}
+                </span>
+              </div>
+            )}
           </div>
         )}
       </div>
-
-      {/* Composer */}
       <form
         onSubmit={(e) => {
           e.preventDefault();
           send();
         }}
-        className="flex items-center gap-2"
+        className="p-4"
       >
-        <input
-          className="flex-1 rounded-xl border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 px-3 py-3 shadow-sm focus:ring-2 focus:ring-slate-300 dark:focus:ring-slate-700"
-          placeholder="Vreau o carte despre prietenie și magie… / I want a novel about friendship and magic"
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-        />
-        <button
-          disabled={sending}
-          className="inline-flex items-center gap-2 rounded-xl bg-slate-900 text-white dark:bg-white dark:text-slate-900 px-4 py-3 hover:opacity-95 disabled:opacity-60"
-        >
-          {sending ? <Spinner className="h-4 w-4" /> : <Send className="h-4 w-4" />} Send
-        </button>
-      </form>
-
-      {/* Audio player + indicator */}
-      <div className="flex items-center gap-2">
-        <audio ref={audioRef} src={audioUrl ?? undefined} controls className="w-full" />
-        {ttsLoading && (
-          <div className="inline-flex items-center gap-1 text-sm text-slate-500">
-            <Spinner /> <Volume2 className="h-3.5 w-3.5" /> Generating audio…
+        <div className="relative">
+          <input
+            className="w-full rounded-full border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 py-3 pr-28 pl-4 focus:outline-none focus:ring-2 focus:ring-slate-300 dark:focus:ring-slate-700"
+            placeholder={recording ? "" : "Ask anything"}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+          />
+          <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={generateImage}
+              className="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
+              aria-label="Generate image"
+            >
+              <ImagePlus className="h-5 w-5" />
+            </button>
+            <Recorder
+              onText={(t) => setInput(t)}
+              onRecordingChange={setRecording}
+            />
+            <button
+              type="submit"
+              disabled={sending}
+              className="text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
+            >
+              {sending ? <Spinner className="h-5 w-5" /> : <Send className="h-5 w-5" />}
+            </button>
           </div>
-        )}
-      </div>
-
+        </div>
+      </form>
+      <audio ref={audioRef} src={audioUrl ?? undefined} className="hidden" />
       {lightbox && <ImageLightbox src={lightbox} onClose={() => setLightbox(null)} />}
     </div>
   );

--- a/frontend/components/MessageBubble.tsx
+++ b/frontend/components/MessageBubble.tsx
@@ -2,7 +2,8 @@
 import React from "react";
 import cn from "classnames";
 import ReactMarkdown from "react-markdown";
-import { Bot, User, Copy, Check } from "lucide-react";
+import { Bot, User, Copy, Check, Volume2 } from "lucide-react";
+import Spinner from "./Spinner";
 
 export type ChatMsg = {
   role: "user" | "assistant";
@@ -24,10 +25,12 @@ function Avatar({ role }: { role: "user" | "assistant" }) {
   );
 }
 
-export default function MessageBubble({ msg, onCopy, onImageClick }: {
+export default function MessageBubble({ msg, onCopy, onImageClick, onSpeak, speaking }: {
   msg: ChatMsg;
   onCopy?: (text: string) => void;
   onImageClick?: (src: string) => void;
+  onSpeak?: () => void;
+  speaking?: boolean;
 }) {
   const [copied, setCopied] = React.useState(false);
   async function doCopy() {
@@ -49,25 +52,41 @@ export default function MessageBubble({ msg, onCopy, onImageClick }: {
     <div className={cn("flex gap-3", msg.role === "user" ? "justify-end" : "justify-start")}>
       {msg.role === "assistant" && <Avatar role="assistant" />}
       <div className="max-w-[80%] space-y-2">
-        <div className={bubbleClasses}>
-          <div className="prose prose-slate dark:prose-invert prose-p:my-2 prose-pre:my-2 prose-strong:font-semibold">
-            <ReactMarkdown>{msg.content}</ReactMarkdown>
+        {msg.content && (
+          <div className={bubbleClasses}>
+            <div className="prose prose-slate dark:prose-invert prose-p:my-2 prose-pre:my-2 prose-strong:font-semibold">
+              <ReactMarkdown>{msg.content}</ReactMarkdown>
+            </div>
+            {msg.role === "assistant" && (
+              <div className="absolute -right-2 -top-2 hidden group-hover:flex gap-1">
+                <button
+                  onClick={doCopy}
+                  className="rounded-full border px-2 py-1 text-xs bg-white/80 dark:bg-slate-900/70 backdrop-blur border-slate-200 dark:border-slate-700"
+                  title="Copy"
+                  aria-label="Copy message"
+                >
+                  {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+                </button>
+                {onSpeak && (
+                  <button
+                    onClick={onSpeak}
+                    className="rounded-full border px-2 py-1 text-xs bg-white/80 dark:bg-slate-900/70 backdrop-blur border-slate-200 dark:border-slate-700"
+                    title="Read aloud"
+                    aria-label="Read aloud"
+                  >
+                    {speaking ? <Spinner className="h-3.5 w-3.5" /> : <Volume2 className="h-3.5 w-3.5" />}
+                  </button>
+                )}
+              </div>
+            )}
           </div>
-          <button
-            onClick={doCopy}
-            className="absolute -right-2 -top-2 hidden group-hover:flex items-center gap-1 rounded-full border px-2 py-1 text-xs bg-white/80 dark:bg-slate-900/70 backdrop-blur border-slate-200 dark:border-slate-700"
-            title="Copy"
-            aria-label="Copy message"
-          >
-            {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-          </button>
-        </div>
+        )}
 
         {msg.imageB64 && (
           <img
             src={`data:image/png;base64,${msg.imageB64}`}
             alt="Generated image"
-            className="w-full rounded-xl border border-slate-200 dark:border-slate-700 cursor-zoom-in hover:opacity-95"
+            className="w-full max-w-xs rounded-xl border border-slate-200 dark:border-slate-700 cursor-zoom-in hover:opacity-95"
             onClick={() => onImageClick?.(`data:image/png;base64,${msg.imageB64}`)}
           />
         )}

--- a/frontend/components/Recorder.tsx
+++ b/frontend/components/Recorder.tsx
@@ -1,45 +1,88 @@
 "use client";
-import { useEffect, useRef, useState } from "react";
-import { Mic } from "lucide-react"; 
+import { useRef, useState } from "react";
+import { Mic } from "lucide-react";
 
-export default function Recorder({ onText }: { onText: (text: string) => void }) {
+export default function Recorder({
+  onText,
+  onRecordingChange,
+  className,
+}: {
+  onText: (text: string) => void;
+  onRecordingChange?: (recording: boolean) => void;
+  className?: string;
+}) {
   const [recording, setRecording] = useState(false);
   const mediaRef = useRef<MediaRecorder | null>(null);
   const chunksRef = useRef<Blob[]>([]);
+  const streamRef = useRef<MediaStream | null>(null);
+  const startTimeRef = useRef<number | null>(null);
 
   async function start() {
-    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-    const mr = new MediaRecorder(stream);
-    chunksRef.current = [];
-    mr.ondataavailable = (e) => { if (e.data.size > 0) chunksRef.current.push(e.data); };
-    mr.onstop = async () => {
-      const blob = new Blob(chunksRef.current, { type: "audio/webm" });
-      const form = new FormData();
-      form.append("file", blob, "voice.webm");
-      const base = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000";
-      const res = await fetch(base + "/stt", { method: "POST", body: form });
-      const data = await res.json();
-      if (data?.text) onText(data.text);
-    };
-    mr.start();
-    mediaRef.current = mr;
-    setRecording(true);
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+      const mr = new MediaRecorder(stream, { mimeType: "audio/webm" });
+      chunksRef.current = [];
+      startTimeRef.current = Date.now();
+      mr.ondataavailable = (e) => {
+        if (e.data.size > 0) chunksRef.current.push(e.data);
+      };
+      mr.onstop = async () => {
+        const duration = startTimeRef.current ? Date.now() - startTimeRef.current : 0;
+        const blob = new Blob(chunksRef.current, { type: "audio/webm" });
+        startTimeRef.current = null;
+        // ignore near-silent or very short captures which can yield random transcripts
+        if (duration < 800 || blob.size < 2000) return;
+        const form = new FormData();
+        form.append("file", blob, "voice.webm");
+        const base = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000";
+        try {
+          const res = await fetch(base + "/stt", { method: "POST", body: form });
+          const data = await res.json();
+          const text = (data?.text || "").trim();
+          if (text) onText(text);
+        } catch (e) {
+          console.error("STT failed", e);
+        }
+      };
+      mr.start();
+      mediaRef.current = mr;
+      setRecording(true);
+      onRecordingChange?.(true);
+    } catch (e) {
+      console.error("Mic access failed", e);
+      setRecording(false);
+    }
   }
 
   function stop() {
     mediaRef.current?.stop();
+    streamRef.current?.getTracks().forEach((t) => t.stop());
     setRecording(false);
+    onRecordingChange?.(false);
   }
 
-   return (
-    <button
-      onClick={() => (recording ? stop() : start())}
-      aria-label={recording ? "Stop recording" : "Start recording"}
-      className={`inline-flex items-center gap-2 rounded border px-3 py-2 ${
-        recording ? "bg-red-600 text-white border-red-700" : "bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700 hover:shadow"
-      }`}
-    >
-      <Mic className="h-4 w-4" /> {recording ? "Stop" : "Record"}
-    </button>
+  return (
+    <div className={`flex items-center ${className || ""}`}>
+      <button
+        type="button"
+        onClick={() => (recording ? stop() : start())}
+        aria-label={recording ? "Stop recording" : "Start recording"}
+        className={`p-2 rounded-full ${
+          recording
+            ? "text-red-600"
+            : "text-slate-500 hover:text-slate-900 dark:text-slate-400 dark:hover:text-slate-100"
+        }`}
+      >
+        <Mic className="h-5 w-5" />
+      </button>
+      {recording && (
+        <div className="ml-2 recording-bars">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <span key={i} />
+          ))}
+        </div>
+      )}
+    </div>
   );
 }

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { Plus, Search, Image as ImageIcon, MessageSquare } from "lucide-react";
+import { Plus, Search, BookOpen, MessageSquare, Trash2 } from "lucide-react";
 import ThemeToggle from "./ThemeToggle";
 
 function useApiBase(){
@@ -10,62 +10,97 @@ function useApiBase(){
 
 type ChatItem = { id: number; title: string };
 
-export default function Sidebar(){
+export default function Sidebar() {
   const base = useApiBase();
   const [q, setQ] = useState("");
   const [chats, setChats] = useState<ChatItem[]>([]);
 
-  async function load(){
-  try {
-    const res = await fetch(base + "/chats");
-    const data = await res.json().catch(() => []);
-    setChats(Array.isArray(data) ? data : []);
-  } catch {
-    setChats([]); // don't crash UI if API is down
+  async function load() {
+    try {
+      const res = await fetch(base + "/chats");
+      const data = await res.json().catch(() => []);
+      setChats(Array.isArray(data) ? data : []);
+    } catch {
+      setChats([]);
+    }
   }
-}
-  useEffect(()=>{ load().catch(()=>{}); },[base]);
 
-  async function newChat(){
-    const res = await fetch(base+"/chats", { method: "POST"});
+  useEffect(() => {
+    load().catch(() => {});
+    window.addEventListener("chats-changed", load);
+    return () => window.removeEventListener("chats-changed", load);
+  }, [base]);
+
+  async function newChat() {
+    const res = await fetch(base + "/chats", { method: "POST" });
     const data = await res.json();
-    window.location.href = "/chat/"+data.id;
+    window.location.href = "/chat/" + data.id;
   }
 
   const filtered = Array.isArray(chats)
-  ? chats.filter(c => !q || c.title.toLowerCase().includes(q.toLowerCase()))
-  : [];
+    ? chats.filter((c) => !q || c.title.toLowerCase().includes(q.toLowerCase()))
+    : [];
 
   return (
-    <aside className="w-72 shrink-0 border-r border-slate-200 dark:border-slate-800 bg-white/60 dark:bg-slate-900/40 backdrop-blur hidden md:flex md:flex-col">
-      <div className="p-3 flex items-center gap-2 border-b border-slate-200 dark:border-slate-800">
-        <button onClick={newChat} className="inline-flex items-center gap-2 rounded-lg bg-slate-900 text-white dark:bg-white dark:text-slate-900 px-3 py-2 hover:opacity-95">
-          <Plus className="h-4 w-4"/> New chat
+    <aside className="hidden w-60 shrink-0 md:flex md:flex-col border-r border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900">
+      <div className="p-3">
+        <button
+          onClick={newChat}
+          className="flex w-full items-center gap-2 rounded-md bg-slate-900 text-white dark:bg-white dark:text-slate-900 px-3 py-2 hover:opacity-90"
+        >
+          <Plus className="h-4 w-4" /> New chat
         </button>
-        <ThemeToggle/>
       </div>
-
-      <div className="p-3 border-b border-slate-200 dark:border-slate-800">
-        <label className="flex items-center gap-2 rounded-lg border px-2 py-1 bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700">
-          <Search className="h-4 w-4"/>
-          <input value={q} onChange={(e)=>setQ(e.target.value)} placeholder="Search chats" className="bg-transparent w-full outline-none py-1"/>
-        </label>
-        <div className="mt-2 flex items-center gap-2 text-sm">
-          <Link href="/library" className="inline-flex items-center gap-1 px-2 py-1 rounded hover:bg-slate-100 dark:hover:bg-slate-800"><ImageIcon className="h-4 w-4"/> Library</Link>
+      <div className="px-3">
+        <div className="relative mb-2">
+          <Search className="absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-slate-500" />
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search chats"
+            className="w-full rounded-md border border-slate-300 dark:border-slate-700 bg-transparent py-2 pl-8 pr-2 text-sm outline-none"
+          />
         </div>
+        <Link
+          href="/library"
+          className="flex items-center gap-2 rounded-md px-2 py-2 text-sm hover:bg-slate-100 dark:hover:bg-slate-800"
+        >
+          <BookOpen className="h-4 w-4" /> Library
+        </Link>
       </div>
-
-      <div className="p-3 space-y-1 overflow-auto">
-        <div className="text-xs uppercase tracking-wide text-slate-500 mb-1">My chats</div>
-        {filtered.map(c => (
-          <Link key={c.id} href={`/chat/${c.id}`} className="flex items-center gap-2 px-2 py-2 rounded-lg hover:bg-slate-100 dark:hover:bg-slate-800">
-            <MessageSquare className="h-4 w-4"/>
-            <span className="truncate">{c.title}</span>
-          </Link>
+      <nav className="mt-2 flex-1 overflow-y-auto px-3 space-y-1">
+        {filtered.map((c) => (
+          <div
+            key={c.id}
+            className="group flex items-center rounded-md px-2 py-2 text-sm hover:bg-slate-100 dark:hover:bg-slate-800"
+          >
+            <Link href={`/chat/${c.id}`} className="flex flex-1 items-center gap-2">
+              <MessageSquare className="h-4 w-4" />
+              <span className="truncate">{c.title}</span>
+            </Link>
+            <button
+              onClick={async (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                await fetch(base + `/chats/${c.id}`, { method: "DELETE" });
+                window.dispatchEvent(new Event("chats-changed"));
+                if (window.location.pathname === `/chat/${c.id}`) {
+                  window.location.href = "/";
+                }
+              }}
+              className="ml-2 opacity-0 group-hover:opacity-100 text-slate-400 hover:text-red-600"
+              aria-label="Delete chat"
+            >
+              <Trash2 className="h-4 w-4" />
+            </button>
+          </div>
         ))}
-        {filtered.length===0 && (
+        {filtered.length === 0 && (
           <div className="text-slate-500 text-sm">No chats yet.</div>
         )}
+      </nav>
+      <div className="p-3 border-t border-slate-200 dark:border-slate-800">
+        <ThemeToggle />
       </div>
     </aside>
   );


### PR DESCRIPTION
## Summary
- generate images from the most recent assistant reply using the in-input image button and persist them with the chat
- expose recorder state to hide the input placeholder while recording and skip ultra-short captures
- swap sidebar library icon to a book glyph so image generation lives only in the chat input
- ignore near-silent recordings and add spinners while chat history and library images load
- show "Generating image…" for image requests and display images without empty bubbles

## Testing
- `npm test` (missing script: "test")
- `npm run lint` (Next.js ESLint plugin warning)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a0fbc1c32c8333becc3f0bcc4b2b44