### PR TITLE
chore: add eslint and basic tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+node_modules
+frontend/node_modules

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,16 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true,
+    "node": true
+  },
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  "ignorePatterns": ["**/node_modules/*"],
+  "rules": {}
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install
+      - run: npm --prefix frontend install
+      - run: npm test
+      - run: npm run lint

--- a/frontend/components/__tests__/ChatWindow.test.tsx
+++ b/frontend/components/__tests__/ChatWindow.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import ChatWindow from '../ChatWindow';
+
+vi.mock('@/lib/user', () => ({
+  getUserId: () => 'test-user'
+}));
+
+beforeEach(() => {
+  global.fetch = vi.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+  ) as any;
+});
+
+test('renders prompt when no messages', () => {
+  render(<ChatWindow />);
+  expect(screen.getByText(/What can I help you with\?/i)).toBeInTheDocument();
+});

--- a/frontend/components/__tests__/Recorder.test.tsx
+++ b/frontend/components/__tests__/Recorder.test.tsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import Recorder from '../Recorder';
+
+test('renders microphone button', () => {
+  render(<Recorder onText={vi.fn()} />);
+  expect(screen.getByLabelText(/start recording/i)).toBeInTheDocument();
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev -p 3000",
     "build": "next build",
     "start": "next start -p 3000",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
    "dependencies": {
      "classnames": "^2.5.1",
@@ -15,15 +16,19 @@
      "react": "^18.3.1",
      "react-dom": "^18.3.1",
      "lucide-react": "^0.441.0",
-     "react-markdown": "^9.0.1"
-   },
+    "react-markdown": "^9.0.1"
+  },
   "devDependencies": {
     "@types/node": "^20.14.10",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@testing-library/jest-dom": "^6.1.0",
+    "@testing-library/react": "^14.1.2",
     "autoprefixer": "^10.4.19",
+    "jsdom": "^24.0.0",
     "postcss": "^8.4.40",
     "tailwindcss": "^3.4.7",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "vitest": "^1.5.0"
   }
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./vitest.setup.ts']
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './')
+    }
+  }
+});

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "llm-project",
+  "private": true,
+  "version": "1.0.0",
+  "description": "A complete RAG demo using **FastAPI**, **ChromaDB Cloud**, and **Next.js** with optional **moderation**, **TTS**, **STT**, and **image generation**.",
+  "scripts": {
+    "test": "npm --prefix frontend test",
+    "lint": "eslint frontend --ext .ts,.tsx"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "eslint": "^8.57.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add root package.json with lint and test scripts
- configure ESLint baseline
- add Vitest setup and minimal tests for ChatWindow and Recorder
- wire test and lint into CI workflow

## Testing
- `npm test` (fails: vitest not found)
- `npm run lint` (fails: eslint not found)


------
https://chatgpt.com/codex/tasks/task_b_68a41c53f1848333bcd782f7b04eb896