### PR TITLE
refactor: use router navigation

### DIFF
--- a/frontend/components/ChatWindow.tsx
+++ b/frontend/components/ChatWindow.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import MessageBubble, { ChatMsg } from "./MessageBubble";
 import TypingDots from "./TypingDots";
 import Spinner from "./Spinner";
@@ -58,6 +59,7 @@ export default function ChatWindow({
   const bottomRef = useRef<HTMLDivElement>(null);
   const base = useApiBase();
   const userId = useMemo(() => getUserId(), []);
+  const router = useRouter();
 
   useEffect(() => {
     if (seedMessages) {
@@ -202,7 +204,8 @@ export default function ChatWindow({
 
       // If we didn't have a chat yet, jump to the newly created chat route
       if (!chatId && data?.chat_id) {
-        window.location.href = "/chat/" + data.chat_id;
+        window.dispatchEvent(new Event("chats-changed"));
+        router.push("/chat/" + data.chat_id);
         return;
       }
 
@@ -235,7 +238,8 @@ export default function ChatWindow({
       );
       const data = await res.json();
       if (!chatId && data?.chat_id) {
-        window.location.href = "/chat/" + data.chat_id;
+        window.dispatchEvent(new Event("chats-changed"));
+        router.push("/chat/" + data.chat_id);
         return;
       }
       if (data?.image_b64) {

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { Plus, Search, BookOpen, MessageSquare, Trash2 } from "lucide-react";
 import ThemeToggle from "./ThemeToggle";
 import { getUserId } from "@/lib/user";
@@ -21,6 +21,7 @@ export default function Sidebar() {
   const [chats, setChats] = useState<ChatItem[]>([]);
   const pathname = usePathname();
   const userId = useMemo(() => getUserId(), []);
+  const router = useRouter();
 
   async function load() {
     try {
@@ -41,7 +42,8 @@ export default function Sidebar() {
   async function newChat() {
     const res = await fetch(base + `/chats?user_id=${userId}`, { method: "POST" });
     const data = await res.json();
-    window.location.href = "/chat/" + data.id;
+    window.dispatchEvent(new Event("chats-changed"));
+    router.push("/chat/" + data.id);
   }
 
   const filtered = Array.isArray(chats)
@@ -104,8 +106,8 @@ export default function Sidebar() {
                 e.stopPropagation();
                 await fetch(base + `/chats/${c.id}?user_id=${userId}`, { method: "DELETE" });
                 window.dispatchEvent(new Event("chats-changed"));
-                if (window.location.pathname === `/chat/${c.id}`) {
-                  window.location.href = "/";
+                if (pathname === `/chat/${c.id}`) {
+                  router.push("/");
                 }
               }}
               className="ml-2 opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-600"


### PR DESCRIPTION
## Summary
- use Next.js router in Sidebar and ChatWindow for client-side navigation
- dispatch chat update events when navigating

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_b_68a41c55495883339ac636e233a434db