### PR TITLE
fix: include lib directory in web Docker image

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -10,6 +10,7 @@ COPY postcss.config.js ./
 COPY tailwind.config.ts ./
 COPY app ./app
 COPY components ./components
+COPY lib ./lib
 
 RUN pnpm install
 RUN pnpm build


### PR DESCRIPTION
## Summary
- copy `lib` into frontend Docker image so `@/lib/user` can be resolved during build

## Testing
- `npm test` *(fails: invariant expected app router to be mounted)*
- `npm run lint` *(fails: no-useless-escape, no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_b_68a44b324aa0833385cb2288eddceacf