### PR TITLE
Allow small talk in chat responses

### DIFF
--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -35,82 +35,99 @@ def chat(body: ChatIn, user_id: str):
     if is_blocked(user_input):
         return {"reply": "Sorry, I can't help with that.", "blocked": True}
 
-    # Retrieve context via RAG
-    context = retrieve(user_input)
-
-    # System prompt and tool schema
-    system_prompt = (
-        "You are Smart Librarian. Use the provided context from a vector search over book blurbs "
-        "to recommend exactly one book. Respond with: Title + 2–3 sentences why it fits. "
-        "If you can infer the exact title, call the tool get_summary_by_title(title) to append the full summary at the end."
-    )
-    tools = [{
-        "type": "function",
-        "function": {
-            "name": "get_summary_by_title",
-            "description": "Return full book summary for an exact title.",
-            "parameters": {
-                "type": "object",
-                "properties": {"title": {"type": "string"}},
-                "required": ["title"]
-            }
-        }
-    }]
-
-    user_input_with_context = f"User question: {user_input}\n\nContext:\n{context}"
-
-    messages = [
-        {"role": "system", "content": system_prompt},
-        {"role": "user", "content": user_input_with_context},
-    ]
-
-    # First model call (may decide to call tool)
-    first = oai.chat.completions.create(model=CHAT_MODEL, messages=messages, tools=tools)
-    msg = first.choices[0].message
+    # Decide whether the user is asking about books
+    keywords = ("book", "novel", "read", "recommend", "author", "literature", "story", "title")
+    is_book_request = any(k in user_input.lower() for k in keywords)
 
     final_reply: str
 
-    # If the model decided to call a tool
-    if getattr(msg, "tool_calls", None):
-        # Add the assistant turn with tool calls
-        assistant_msg = {
-            "role": "assistant",
-            "content": msg.content or "",
-            "tool_calls": [
-                {
-                    "id": tc.id,
-                    "type": "function",
-                    "function": {
-                        "name": tc.function.name,
-                        "arguments": tc.function.arguments,
-                    },
-                }
-                for tc in msg.tool_calls
-            ],
-        }
-        messages.append(assistant_msg)
-
-        # Execute tools and add tool results
-        for call in msg.tool_calls:
-            try:
-                args = json.loads(call.function.arguments or "{}")
-            except Exception:
-                args = {}
-            title = (args or {}).get("title", "") or ""
-            summary = get_summary_by_title(title) if title else "Summary not found."
-            messages.append({
-                "role": "tool",
-                "tool_call_id": call.id,
-                "name": "get_summary_by_title",
-                "content": summary,
-            })
-
-        # Second model call with tool results included
-        final = oai.chat.completions.create(model=CHAT_MODEL, messages=messages)
-        final_reply = final.choices[0].message.content or ""
+    if not is_book_request:
+        # Light conversation branch
+        system_prompt = (
+            "You are Smart Librarian. Engage in brief, friendly conversation. "
+            "Keep replies light, and if the user asks about books you can help with recommendations."
+        )
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_input},
+        ]
+        reply = oai.chat.completions.create(model=CHAT_MODEL, messages=messages)
+        final_reply = reply.choices[0].message.content or ""
     else:
-        # No tool calls → reply directly
-        final_reply = msg.content or ""
+        # Retrieve context via RAG for book requests
+        context = retrieve(user_input)
+
+        # System prompt and tool schema for recommendations
+        system_prompt = (
+            "You are Smart Librarian. Use the provided context from a vector search over book blurbs "
+            "to recommend exactly one book. Respond with: Title + 2–3 sentences why it fits. "
+            "If you can infer the exact title, call the tool get_summary_by_title(title) to append the full summary at the end."
+        )
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "get_summary_by_title",
+                "description": "Return full book summary for an exact title.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"title": {"type": "string"}},
+                    "required": ["title"]
+                }
+            }
+        }]
+
+        user_input_with_context = f"User question: {user_input}\n\nContext:\n{context}"
+
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_input_with_context},
+        ]
+
+        # First model call (may decide to call tool)
+        first = oai.chat.completions.create(model=CHAT_MODEL, messages=messages, tools=tools)
+        msg = first.choices[0].message
+
+        # If the model decided to call a tool
+        if getattr(msg, "tool_calls", None):
+            # Add the assistant turn with tool calls
+            assistant_msg = {
+                "role": "assistant",
+                "content": msg.content or "",
+                "tool_calls": [
+                    {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {
+                            "name": tc.function.name,
+                            "arguments": tc.function.arguments,
+                        },
+                    }
+                    for tc in msg.tool_calls
+                ],
+            }
+            messages.append(assistant_msg)
+
+            # Execute tools and add tool results
+            for call in msg.tool_calls:
+                try:
+                    args = json.loads(call.function.arguments or "{}")
+                except Exception:
+                    args = {}
+                title = (args or {}).get("title", "") or ""
+                summary = get_summary_by_title(title) if title else "Summary not found."
+                messages.append({
+                    "role": "tool",
+                    "tool_call_id": call.id,
+                    "name": "get_summary_by_title",
+                    "content": summary,
+                })
+
+            # Second model call with tool results included
+            final = oai.chat.completions.create(model=CHAT_MODEL, messages=messages)
+            final_reply = final.choices[0].message.content or ""
+        else:
+            # No tool calls → reply directly
+            final_reply = msg.content or ""
 
     # Persist conversation: create chat if needed, then store messages
     chat_id = body.chat_id


### PR DESCRIPTION
## Summary
- detect whether a message is book-related and skip book recommendations for small-talk
- retain RAG-based recommendation flow for book queries

## Testing
- `python -m py_compile backend/app/routers/chat.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aff5e127b48333987ad40fb7396d5b