### PR TITLE
Allow small talk in chat responses

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,15 +1,39 @@
-from sqlmodel import SQLModel, create_engine, Session
 import os
+
+from sqlalchemy import inspect
+from sqlmodel import SQLModel, create_engine, Session
 
 DB_URL = os.getenv("DB_URL", "sqlite:///data/app.db")
 # For SQLite, need check_same_thread=False when used in threaded servers
-engine = create_engine(DB_URL, connect_args={"check_same_thread": False} if DB_URL.startswith("sqlite") else {})
+engine = create_engine(
+    DB_URL,
+    connect_args={"check_same_thread": False} if DB_URL.startswith("sqlite") else {},
+)
 
 def init_db():
-    # Ensure the data directory exists for sqlite
+    """Create tables and backfill missing columns on older databases."""
     if DB_URL.startswith("sqlite"):
         os.makedirs("data", exist_ok=True)
+
     SQLModel.metadata.create_all(engine)
 
+    with engine.begin() as conn:
+        inspector = inspect(conn)
+        tables = set(inspector.get_table_names())
+
+        def ensure(table: str, column: str):
+            if table not in tables:
+                return
+            cols = {c["name"] for c in inspector.get_columns(table)}
+            if column not in cols:
+                conn.exec_driver_sql(
+                    f"ALTER TABLE {table} ADD COLUMN {column} TEXT DEFAULT ''"
+                )
+
+        ensure("chat", "user_id")
+        ensure("imageasset", "user_id")
+
+
 def get_session() -> Session:
+    init_db()
     return Session(engine)

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -1,8 +1,6 @@
-from __future__ import annotations
-
 from fastapi import APIRouter
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, List
 from datetime import datetime
 from openai import OpenAI
 import os, json
@@ -35,82 +33,120 @@ def chat(body: ChatIn, user_id: str):
     if is_blocked(user_input):
         return {"reply": "Sorry, I can't help with that.", "blocked": True}
 
-    # Retrieve context via RAG
-    context = retrieve(user_input)
+    # Retrieve recent conversation for context (up to 20 messages)
+    history: List[Message] = []
+    if body.chat_id:
+        with get_session() as s:
+            chat = s.exec(
+                select(Chat).where(Chat.id == body.chat_id, Chat.user_id == user_id)
+            ).first()
+            if chat:
+                history = s.exec(
+                    select(Message)
+                    .where(Message.chat_id == chat.id)
+                    .order_by(Message.id.desc())
+                    .limit(20)
+                ).all()
+                history.reverse()
 
-    # System prompt and tool schema
-    system_prompt = (
-        "You are Smart Librarian. Use the provided context from a vector search over book blurbs "
-        "to recommend exactly one book. Respond with: Title + 2–3 sentences why it fits. "
-        "If you can infer the exact title, call the tool get_summary_by_title(title) to append the full summary at the end."
-    )
-    tools = [{
-        "type": "function",
-        "function": {
-            "name": "get_summary_by_title",
-            "description": "Return full book summary for an exact title.",
-            "parameters": {
-                "type": "object",
-                "properties": {"title": {"type": "string"}},
-                "required": ["title"]
-            }
-        }
-    }]
+    # Decide whether the user is asking about books (considering prior turns)
+    keywords = ("book", "novel", "read", "recommend", "author", "literature", "story", "title")
+    is_book_request = any(k in user_input.lower() for k in keywords)
+    if not is_book_request:
+        for msg in reversed(history):
+            if any(k in msg.content.lower() for k in keywords):
+                is_book_request = True
+                break
 
-    user_input_with_context = f"User question: {user_input}\n\nContext:\n{context}"
-
-    messages = [
-        {"role": "system", "content": system_prompt},
-        {"role": "user", "content": user_input_with_context},
-    ]
-
-    # First model call (may decide to call tool)
-    first = oai.chat.completions.create(model=CHAT_MODEL, messages=messages, tools=tools)
-    msg = first.choices[0].message
-
+    messages = []
     final_reply: str
 
-    # If the model decided to call a tool
-    if getattr(msg, "tool_calls", None):
-        # Add the assistant turn with tool calls
-        assistant_msg = {
-            "role": "assistant",
-            "content": msg.content or "",
-            "tool_calls": [
-                {
-                    "id": tc.id,
-                    "type": "function",
-                    "function": {
-                        "name": tc.function.name,
-                        "arguments": tc.function.arguments,
-                    },
-                }
-                for tc in msg.tool_calls
-            ],
-        }
-        messages.append(assistant_msg)
-
-        # Execute tools and add tool results
-        for call in msg.tool_calls:
-            try:
-                args = json.loads(call.function.arguments or "{}")
-            except Exception:
-                args = {}
-            title = (args or {}).get("title", "") or ""
-            summary = get_summary_by_title(title) if title else "Summary not found."
-            messages.append({
-                "role": "tool",
-                "tool_call_id": call.id,
-                "name": "get_summary_by_title",
-                "content": summary,
-            })
-
-        # Second model call with tool results included
-        final = oai.chat.completions.create(model=CHAT_MODEL, messages=messages)
-        final_reply = final.choices[0].message.content or ""
+    if not is_book_request:
+        # Light conversation branch
+        system_prompt = (
+            "You are Smart Librarian. Engage in brief, friendly conversation. "
+            "Keep replies light, and if the user asks about books you can help with recommendations."
+        )
+        messages.append({"role": "system", "content": system_prompt})
+        messages.extend({"role": m.role, "content": m.content} for m in history)
+        messages.append({"role": "user", "content": user_input})
+        reply = oai.chat.completions.create(model=CHAT_MODEL, messages=messages)
+        final_reply = reply.choices[0].message.content or ""
     else:
-        # No tool calls → reply directly
-        final_reply = msg.content or ""
+        # Retrieve context via RAG for book requests
+        context = retrieve(user_input)
+
+        # System prompt and tool schema for recommendations
+        system_prompt = (
+            "You are Smart Librarian, a friendly conversational assistant. Use the provided context from "
+            "a vector search over book blurbs to recommend a single book in a natural tone. "
+            "You may briefly relate to the user's comments before suggesting the book. If you can infer the exact "
+            "title, call the tool get_summary_by_title(title) to append the full summary at the end."
+        )
+        tools = [{
+            "type": "function",
+            "function": {
+                "name": "get_summary_by_title",
+                "description": "Return full book summary for an exact title.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"title": {"type": "string"}},
+                    "required": ["title"]
+                }
+            }
+        }]
+
+        user_input_with_context = f"User question: {user_input}\n\nContext:\n{context}"
+
+        messages.append({"role": "system", "content": system_prompt})
+        messages.extend({"role": m.role, "content": m.content} for m in history)
+        messages.append({"role": "user", "content": user_input_with_context})
+
+        # First model call (may decide to call tool)
+        first = oai.chat.completions.create(model=CHAT_MODEL, messages=messages, tools=tools)
+        msg = first.choices[0].message
+
+        # If the model decided to call a tool
+        if getattr(msg, "tool_calls", None):
+            # Add the assistant turn with tool calls
+            assistant_msg = {
+                "role": "assistant",
+                "content": msg.content or "",
+                "tool_calls": [
+                    {
+                        "id": tc.id,
+                        "type": "function",
+                        "function": {
+                            "name": tc.function.name,
+                            "arguments": tc.function.arguments,
+                        },
+                    }
+                    for tc in msg.tool_calls
+                ],
+            }
+            messages.append(assistant_msg)
+
+            # Execute tools and add tool results
+            for call in msg.tool_calls:
+                try:
+                    args = json.loads(call.function.arguments or "{}")
+                except Exception:
+                    args = {}
+                title = (args or {}).get("title", "") or ""
+                summary = get_summary_by_title(title) if title else "Summary not found."
+                messages.append({
+                    "role": "tool",
+                    "tool_call_id": call.id,
+                    "name": "get_summary_by_title",
+                    "content": summary,
+                })
+
+            # Second model call with tool results included
+            final = oai.chat.completions.create(model=CHAT_MODEL, messages=messages)
+            final_reply = final.choices[0].message.content or ""
+        else:
+            # No tool calls → reply directly
+            final_reply = msg.content or ""
 
     # Persist conversation: create chat if needed, then store messages
     chat_id = body.chat_id


### PR DESCRIPTION
## Summary
- load recent chat history and use it for context and intent detection
- use a friendlier system prompt and include prior turns when generating book recommendations
- ensure old databases add missing `user_id` columns for both `chat` and `imageasset` tables

## Testing
- `python -m py_compile backend/app/db.py backend/app/routers/history.py backend/app/routers/chat.py backend/app/routers/image.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68aff5e127b48333987ad40fb7396d5b